### PR TITLE
Adding openssl-musl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.openssl-musl?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=176&branchName=master)
+
+# openssl-musl
+
+OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "openssl-musl"

--- a/ca-dir.patch
+++ b/ca-dir.patch
@@ -1,0 +1,58 @@
+diff -ur openssl-1.0.2e.orig/apps/CA.pl.in openssl-1.0.2e/apps/CA.pl.in
+--- openssl-1.0.2e.orig/apps/CA.pl.in	2015-12-03 14:04:23.000000000 +0000
++++ openssl-1.0.2e/apps/CA.pl.in	2016-01-20 23:58:07.330911590 +0000
+@@ -53,7 +53,7 @@
+ $X509="$openssl x509";
+ $PKCS12="$openssl pkcs12";
+ 
+-$CATOP="./demoCA";
++$CATOP="@prefix@/ssl";
+ $CAKEY="cakey.pem";
+ $CAREQ="careq.pem";
+ $CACERT="cacert.pem";
+diff -ur openssl-1.0.2e.orig/apps/CA.sh openssl-1.0.2e/apps/CA.sh
+--- openssl-1.0.2e.orig/apps/CA.sh	2015-12-03 14:04:23.000000000 +0000
++++ openssl-1.0.2e/apps/CA.sh	2016-01-20 23:58:07.340911932 +0000
+@@ -68,7 +68,7 @@
+ X509="$OPENSSL x509"
+ PKCS12="openssl pkcs12"
+ 
+-if [ -z "$CATOP" ] ; then CATOP=./demoCA ; fi
++if [ -z "$CATOP" ] ; then CATOP=@prefix@/ssl ; fi
+ CAKEY=./cakey.pem
+ CAREQ=./careq.pem
+ CACERT=./cacert.pem
+diff -ur openssl-1.0.2e.orig/apps/openssl.cnf openssl-1.0.2e/apps/openssl.cnf
+--- openssl-1.0.2e.orig/apps/openssl.cnf	2015-12-03 14:04:23.000000000 +0000
++++ openssl-1.0.2e/apps/openssl.cnf	2016-01-21 00:00:37.936048877 +0000
+@@ -39,7 +39,7 @@
+ ####################################################################
+ [ CA_default ]
+ 
+-dir		= ./demoCA		# Where everything is kept
++dir		= @prefix@/ssl		# Where everything is kept
+ certs		= $dir/certs		# Where the issued certs are kept
+ crl_dir		= $dir/crl		# Where the issued crl are kept
+ database	= $dir/index.txt	# database index file.
+@@ -47,7 +47,7 @@
+ 					# several ctificates with same subject.
+ new_certs_dir	= $dir/newcerts		# default place for new certs.
+ 
+-certificate	= $dir/cacert.pem 	# The CA certificate
++certificate	= @cacerts_prefix@/ssl/certs/cacert.pem # The CA certificate
+ serial		= $dir/serial 		# The current serial number
+ crlnumber	= $dir/crlnumber	# the current crl number
+ 					# must be commented out to leave a V1 CRL
+--- openssl-1.0.2j.orig/crypto/cryptlib.h	2016-09-26 09:49:07.000000000 +0000
++++ openssl-1.0.2j/crypto/cryptlib.h	2017-07-11 15:59:45.444998911 +0000
+@@ -81,8 +81,8 @@
+ 
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+-#  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_DIR           "@cacerts_prefix@/ssl/certs"
++#  define X509_CERT_FILE          "@cacerts_prefix@/ssl/cert.pem"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ # else
+ #  define X509_CERT_AREA          "SSLROOT:[000000]"

--- a/controls/opens_ssl_musl_test.rb
+++ b/controls/opens_ssl_musl_test.rb
@@ -1,0 +1,41 @@
+title 'Tests to confirm openssl-musl works as expected'
+
+plan_name = input('plan_name', value: 'openssl-musl')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-openssl-musl' do
+  impact 1.0
+  title 'Ensure openssl-musl works'
+  desc '
+  For openssl-musl, we check that the executable exists and that it behaves as expected.
+  '
+  openssl_musl_pkg = command("#{hab_path} pkg path #{plan_ident}")
+  describe openssl_musl_pkg do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  openssl_musl_pkg = openssl_musl_pkg.stdout.strip
+
+  describe file("#{openssl_musl_pkg}/bin/openssl") do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  # The below tests are not working with the current version of openssl-musl.
+  # For more information see: https://github.com/chef-base-plans/openssl-musl/issues/1
+  #
+  # describe command("#{openssl_musl_pkg}/bin/openssl version") do
+  #   its('exit_status') { should eq 0 }
+  #   its('stdout') { should_not be_empty }
+  #   its('stdout') { should match /#{openssl_musl_pkg.split('/')[5]}/ }
+  #   its('stderr') { should be_empty }
+  # end
+  #
+  # describe command("echo 'hello world' | #{openssl_musl_pkg}/bin/openssl enc -base64") do
+  #   its('exit_status') { should eq 0 }
+  #   its('stdout') { should_not be_empty }
+  #   its('stdout') { should match /aGVsbG8gd29ybGQK/ }
+  #   its('stderr') { should be_empty }
+  # end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: openssl-musl
+title: Habitat Core Plan openssl-musl
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan openssl-musl
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,142 @@
+pkg_name=openssl-musl
+_distname="openssl"
+pkg_origin=core
+pkg_version="1.0.2t"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+OpenSSL is an open source project that provides a robust, commercial-grade, \
+and full-featured toolkit for the Transport Layer Security (TLS) and Secure \
+Sockets Layer (SSL) protocols. It is also a general-purpose cryptography \
+library.\
+"
+pkg_upstream_url="https://www.openssl.org"
+pkg_license=('OpenSSL')
+pkg_source="https://www.openssl.org/source/${_distname}-${pkg_version}.tar.gz"
+pkg_shasum="14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc"
+pkg_dirname="${_distname}-${pkg_version}"
+pkg_deps=(
+  core/musl
+  core/zlib-musl
+  core/cacerts
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+  core/grep
+  core/perl
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+_common_prepare() {
+  do_default_prepare
+
+  # Set CA dir to `$pkg_prefix/ssl` by default and use the cacerts from the
+  # `cacerts` package. Note that `patch(1)` is making backups because
+  # we need an original for the test suite.
+  sed -e "s,@prefix@,$pkg_prefix,g" \
+      -e "s,@cacerts_prefix@,$(pkg_path_for cacerts),g" \
+      "$PLAN_CONTEXT/ca-dir.patch" \
+      | patch -p1 --backup
+
+  # The openssl build process hard codes /bin/rm in many places. Unfortunately
+  # we cannot modify the contents of the build scripts to fix this or else we
+  # risk violating the sanctity of the official fips build process.
+  # Instead, we link rm to maintain integrity.
+  # Reference: https://www.openssl.org/docs/fips/UserGuide-2.0.pdf
+  if [[ ! -f "/bin/rm" ]]; then
+    hab pkg binlink core/coreutils rm --dest /bin
+    BINLINKED_RM=true
+  fi
+}
+
+do_prepare() {
+  PLAN_CONTEXT="$(abspath "$PLAN_CONTEXT")" _common_prepare
+
+#  dynamic_linker="$(pkg_path_for musl)/lib/ld-musl-x86_64.so.1"
+  dynamic_linker="$(pkg_path_for musl)/lib/libc.so"
+  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
+
+  export BUILD_CC=musl-gcc
+  build_line "Setting BUILD_CC=$BUILD_CC"
+}
+
+do_build() {
+  # Set PERL var for scripts in `do_check` that use Perl
+  PERL=$(pkg_path_for core/perl)/bin/perl
+  export PERL
+  "$(pkg_path_for core/perl)/bin/perl" ./Configure \
+    no-idea \
+    no-mdc2 \
+    no-rc5 \
+    no-sslv2 \
+    no-sslv3 \
+    no-comp \
+    no-zlib \
+    shared \
+    disable-gost \
+    --prefix="${pkg_prefix}" \
+    --openssldir=ssl \
+    linux-x86_64
+
+  make CC= depend
+  make --jobs="$(nproc)" CC="$BUILD_CC"
+}
+
+do_check() {
+  # Flip back to the original sources to satisfy the test suite, but keep the
+  # final version for packaging.
+  for f in apps/CA.pl.in apps/CA.sh apps/openssl.cnf; do
+    cp -fv $f ${f}.final
+    cp -fv ${f}.orig $f
+  done
+
+  make test
+
+  # Finally, restore the final sources to their original locations.
+  for f in apps/CA.pl.in apps/CA.sh apps/openssl.cnf; do
+    cp -fv ${f}.final $f
+  done
+}
+
+do_install() {
+  do_default_install
+
+  # Remove dependency on Perl at runtime
+  rm -rfv "$pkg_prefix/ssl/misc" "$pkg_prefix/bin/c_rehash"
+}
+
+do_end() {
+  do_default_end
+
+  # Clean up binlinked rm if we made it
+  if [[ $BINLINKED_RM == true ]]; then
+    rm -f /bin/rm
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/grep
+    core/perl
+    core/diffutils
+    core/make
+    core/patch
+  )
+fi


### PR DESCRIPTION
Migration of openssl-musl from core plans.  Adding InSpec tests but some are commented as per:  https://github.com/chef-base-plans/openssl-musl/issues/1

```
Profile: Habitat Core Plan openssl-musl (openssl-musl)
Version: 0.1.0
Target:  local://

  ✔  core-plans-openssl-musl: Ensure openssl-musl works
     ✔  Command: `hab pkg path habskp/openssl-musl` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/openssl-musl` stdout is expected not to be empty
     ✔  File /hab/pkgs/habskp/openssl-musl/1.0.2t/20200615134742/bin/openssl is expected to exist
     ✔  File /hab/pkgs/habskp/openssl-musl/1.0.2t/20200615134742/bin/openssl is expected to be executable


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 4 successful, 0 failures, 0 skipped
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
